### PR TITLE
fix(migrations): add delete cascade fk action for every fk

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -88,7 +88,7 @@ export const libraries = sqliteTable("libraries", {
     .notNull(),
   serverName: text()
     .notNull()
-    .references(() => servers.serverName),
+    .references(() => servers.serverName, { onDelete: "cascade" }),
   createdAt: integer({ mode: "timestamp_ms" })
     .$default(() => new Date()),
   updatedAt: integer({ mode: "timestamp_ms" })
@@ -128,7 +128,7 @@ export const artists = sqliteTable("artists", {
     .notNull(),
   library: text()
     .notNull()
-    .references(() => libraries.uuid),
+    .references(() => libraries.uuid, { onDelete: "cascade" }),
   summary: text(),
   createdAt: integer({ mode: "timestamp_ms" })
     .$default(() => new Date()),
@@ -168,10 +168,10 @@ export const albums = sqliteTable("albums", {
   summary: text(),
   library: text()
     .notNull()
-    .references(() => libraries.uuid),
+    .references(() => libraries.uuid, { onDelete: "cascade" }),
   artist: text()
     .notNull()
-    .references(() => artists.uuid),
+    .references(() => artists.uuid, { onDelete: "cascade" }),
   createdAt: integer({ mode: "timestamp_ms" })
     .$default(() => new Date()),
   updatedAt: integer({ mode: "timestamp_ms" })
@@ -213,13 +213,13 @@ export const tracks = sqliteTable("tracks", {
     .notNull(),
   library: text()
     .notNull()
-    .references(() => libraries.uuid),
+    .references(() => libraries.uuid, { onDelete: "cascade" }),
   artist: text()
     .notNull()
-    .references(() => artists.uuid),
+    .references(() => artists.uuid, { onDelete: "cascade" }),
   album: text()
     .notNull()
-    .references(() => albums.uuid),
+    .references(() => albums.uuid, { onDelete: "cascade" }),
   trackNumber: integer()
     .notNull()
     .default(0),

--- a/src/lib/server/db/migrations/0008_hot_exiles.sql
+++ b/src/lib/server/db/migrations/0008_hot_exiles.sql
@@ -1,0 +1,77 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_albums` (
+	`title` text NOT NULL,
+	`uuid` text PRIMARY KEY NOT NULL,
+	`image` text,
+	`key` text NOT NULL,
+	`synced` integer DEFAULT false NOT NULL,
+	`summary` text,
+	`library` text NOT NULL,
+	`artist` text NOT NULL,
+	`created_at` integer,
+	`updated_at` integer,
+	FOREIGN KEY (`library`) REFERENCES `libraries`(`uuid`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`artist`) REFERENCES `artists`(`uuid`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_albums`("title", "uuid", "image", "key", "synced", "summary", "library", "artist", "created_at", "updated_at") SELECT "title", "uuid", "image", "key", "synced", "summary", "library", "artist", "created_at", "updated_at" FROM `albums`;--> statement-breakpoint
+DROP TABLE `albums`;--> statement-breakpoint
+ALTER TABLE `__new_albums` RENAME TO `albums`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `albums_key_unique` ON `albums` (`key`);--> statement-breakpoint
+CREATE TABLE `__new_artists` (
+	`title` text NOT NULL,
+	`uuid` text PRIMARY KEY NOT NULL,
+	`image` text,
+	`key` text NOT NULL,
+	`synced` integer DEFAULT false NOT NULL,
+	`library` text NOT NULL,
+	`summary` text,
+	`created_at` integer,
+	`updated_at` integer,
+	FOREIGN KEY (`library`) REFERENCES `libraries`(`uuid`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_artists`("title", "uuid", "image", "key", "synced", "library", "summary", "created_at", "updated_at") SELECT "title", "uuid", "image", "key", "synced", "library", "summary", "created_at", "updated_at" FROM `artists`;--> statement-breakpoint
+DROP TABLE `artists`;--> statement-breakpoint
+ALTER TABLE `__new_artists` RENAME TO `artists`;--> statement-breakpoint
+CREATE UNIQUE INDEX `artists_key_unique` ON `artists` (`key`);--> statement-breakpoint
+CREATE TABLE `__new_libraries` (
+	`title` text NOT NULL,
+	`uuid` text PRIMARY KEY NOT NULL,
+	`image` text NOT NULL,
+	`path` text NOT NULL,
+	`key` text NOT NULL,
+	`current_library` integer DEFAULT false NOT NULL,
+	`server_name` text NOT NULL,
+	`created_at` integer,
+	`updated_at` integer,
+	FOREIGN KEY (`server_name`) REFERENCES `servers`(`server_name`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_libraries`("title", "uuid", "image", "path", "key", "current_library", "server_name", "created_at", "updated_at") SELECT "title", "uuid", "image", "path", "key", "current_library", "server_name", "created_at", "updated_at" FROM `libraries`;--> statement-breakpoint
+DROP TABLE `libraries`;--> statement-breakpoint
+ALTER TABLE `__new_libraries` RENAME TO `libraries`;--> statement-breakpoint
+CREATE UNIQUE INDEX `libraries_key_unique` ON `libraries` (`key`);--> statement-breakpoint
+CREATE TABLE `__new_tracks` (
+	`title` text NOT NULL,
+	`uuid` text PRIMARY KEY NOT NULL,
+	`key` text NOT NULL,
+	`path` text NOT NULL,
+	`duration` integer NOT NULL,
+	`synced` integer DEFAULT false NOT NULL,
+	`library` text NOT NULL,
+	`artist` text NOT NULL,
+	`album` text NOT NULL,
+	`track_number` integer DEFAULT 0 NOT NULL,
+	`created_at` integer,
+	`updated_at` integer,
+	FOREIGN KEY (`library`) REFERENCES `libraries`(`uuid`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`artist`) REFERENCES `artists`(`uuid`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`album`) REFERENCES `albums`(`uuid`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_tracks`("title", "uuid", "key", "path", "duration", "synced", "library", "artist", "album", "track_number", "created_at", "updated_at") SELECT "title", "uuid", "key", "path", "duration", "synced", "library", "artist", "album", "track_number", "created_at", "updated_at" FROM `tracks`;--> statement-breakpoint
+DROP TABLE `tracks`;--> statement-breakpoint
+ALTER TABLE `__new_tracks` RENAME TO `tracks`;--> statement-breakpoint
+CREATE UNIQUE INDEX `tracks_key_unique` ON `tracks` (`key`);

--- a/src/lib/server/db/migrations/meta/0008_snapshot.json
+++ b/src/lib/server/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,590 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5008d033-f0e0-4abd-b56d-1be5e31e8fe4",
+  "prevId": "701bcdde-0848-449f-81ed-edd0af0c9c48",
+  "tables": {
+    "albums": {
+      "name": "albums",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "library": {
+          "name": "library",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "albums_key_unique": {
+          "name": "albums_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "albums_library_libraries_uuid_fk": {
+          "name": "albums_library_libraries_uuid_fk",
+          "tableFrom": "albums",
+          "tableTo": "libraries",
+          "columnsFrom": [
+            "library"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "albums_artist_artists_uuid_fk": {
+          "name": "albums_artist_artists_uuid_fk",
+          "tableFrom": "albums",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artists": {
+      "name": "artists",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "library": {
+          "name": "library",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "artists_key_unique": {
+          "name": "artists_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "artists_library_libraries_uuid_fk": {
+          "name": "artists_library_libraries_uuid_fk",
+          "tableFrom": "artists",
+          "tableTo": "libraries",
+          "columnsFrom": [
+            "library"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "libraries": {
+      "name": "libraries",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_library": {
+          "name": "current_library",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "libraries_key_unique": {
+          "name": "libraries_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "libraries_server_name_servers_server_name_fk": {
+          "name": "libraries_server_name_servers_server_name_fk",
+          "tableFrom": "libraries",
+          "tableTo": "servers",
+          "columnsFrom": [
+            "server_name"
+          ],
+          "columnsTo": [
+            "server_name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "servers": {
+      "name": "servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "x_plex_token": {
+          "name": "x_plex_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "servers_serverName_unique": {
+          "name": "servers_serverName_unique",
+          "columns": [
+            "server_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks": {
+      "name": "tracks",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "library": {
+          "name": "library",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album": {
+          "name": "album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_number": {
+          "name": "track_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tracks_key_unique": {
+          "name": "tracks_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "tracks_library_libraries_uuid_fk": {
+          "name": "tracks_library_libraries_uuid_fk",
+          "tableFrom": "tracks",
+          "tableTo": "libraries",
+          "columnsFrom": [
+            "library"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tracks_artist_artists_uuid_fk": {
+          "name": "tracks_artist_artists_uuid_fk",
+          "tableFrom": "tracks",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tracks_album_albums_uuid_fk": {
+          "name": "tracks_album_albums_uuid_fk",
+          "tableFrom": "tracks",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "album"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/lib/server/db/migrations/meta/_journal.json
+++ b/src/lib/server/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1756601340955,
       "tag": "0007_free_eddie_brock",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1764547202310,
+      "tag": "0008_hot_exiles",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Fixed a bug causing ```LibsqlError: SQLITE_CONSTRAINT_FOREIGNKEY: FOREIGN KEY constraint failed``` on delete when syncing plex db with local db